### PR TITLE
Remove token size from execute sale instruction args

### DIFF
--- a/js/idl/reward_center.json
+++ b/js/idl/reward_center.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.2",
   "name": "reward_center",
   "instructions": [
     {
@@ -808,10 +808,6 @@
           {
             "name": "programAsSignerBump",
             "type": "u8"
-          },
-          {
-            "name": "tokenSize",
-            "type": "u64"
           }
         ]
       }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holaplex/hpl-reward-center",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "HPL Reward Center JavaScript API.",
   "main": "dist/src/generated/index.js",
   "types": "dist/src/generated/index.d.ts",

--- a/js/src/generated/types/ExecuteSaleParams.ts
+++ b/js/src/generated/types/ExecuteSaleParams.ts
@@ -11,7 +11,6 @@ export type ExecuteSaleParams = {
   freeTradeStateBump: number;
   sellerTradeStateBump: number;
   programAsSignerBump: number;
-  tokenSize: beet.bignum;
 };
 
 /**
@@ -24,7 +23,6 @@ export const executeSaleParamsBeet = new beet.BeetArgsStruct<ExecuteSaleParams>(
     ['freeTradeStateBump', beet.u8],
     ['sellerTradeStateBump', beet.u8],
     ['programAsSignerBump', beet.u8],
-    ['tokenSize', beet.u64],
   ],
   'ExecuteSaleParams',
 );

--- a/program/Cargo.lock
+++ b/program/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "hpl-reward-center"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hpl-reward-center"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Reward buyers and sellers of NFTs with spl tokens"
 authors = ["Holaplex Developers <hola@holaplex.com>"]

--- a/program/src/execute_sale/mod.rs
+++ b/program/src/execute_sale/mod.rs
@@ -24,7 +24,6 @@ pub struct ExecuteSaleParams {
     pub free_trade_state_bump: u8,
     pub seller_trade_state_bump: u8,
     pub program_as_signer_bump: u8,
-    pub token_size: u64,
 }
 
 #[derive(Accounts, Clone)]
@@ -196,7 +195,7 @@ pub struct ExecuteSale<'info> {
             auction_house.treasury_mint.as_ref(),
             token_mint.key().as_ref(),
             &u64::MAX.to_le_bytes(),
-            &execute_sale_params.token_size.to_le_bytes()
+            &listing.token_size.to_le_bytes()
         ],
         seeds::program = auction_house_program,
         bump = execute_sale_params.seller_trade_state_bump,
@@ -215,7 +214,7 @@ pub struct ExecuteSale<'info> {
             auction_house.treasury_mint.as_ref(),
             token_account.mint.as_ref(),
             &0u64.to_le_bytes(),
-            &execute_sale_params.token_size.to_le_bytes()
+            &listing.token_size.to_le_bytes()
         ],
         seeds::program = auction_house_program,
         bump = execute_sale_params.free_trade_state_bump
@@ -285,7 +284,6 @@ pub fn handler(
         escrow_payment_bump,
         free_trade_state_bump,
         program_as_signer_bump,
-        token_size,
         ..
     }: ExecuteSaleParams,
 ) -> Result<()> {
@@ -296,6 +294,7 @@ pub fn handler(
     let metadata = &ctx.accounts.metadata;
     let token_account = &ctx.accounts.token_account;
     let price = seller_listing.price;
+    let token_size = seller_listing.token_size;
 
     let auction_house_key = auction_house.key();
 

--- a/sdk/reward-center/src/lib.rs
+++ b/sdk/reward-center/src/lib.rs
@@ -408,8 +408,8 @@ pub fn execute_sale(
     }: ExecuteSaleAccounts,
     ExecuteSaleData {
         token_size,
-        reward_mint,
         price,
+        reward_mint,
     }: ExecuteSaleData,
 ) -> Instruction {
     let (reward_center, _) = find_reward_center_address(&auction_house);
@@ -500,7 +500,6 @@ pub fn execute_sale(
             free_trade_state_bump,
             program_as_signer_bump,
             seller_trade_state_bump,
-            token_size,
         },
     }
     .data();


### PR DESCRIPTION
## Changes
- Pull the otken size from the listing instead of instruction args