### PR TITLE
Close Offer Account in Instruction Handler

### DIFF
--- a/program/src/errors.rs
+++ b/program/src/errors.rs
@@ -31,10 +31,16 @@ pub enum RewardCenterError {
     SellerTokenAccountMismatch,
 
     // 6007
-    #[msg("The number of decimals for auction house treasury mint do not match reward mint decimals")]
+    #[msg(
+        "The number of decimals for auction house treasury mint do not match reward mint decimals"
+    )]
     RewardMintDecimalMismatch,
 
     // 6008
     #[msg("The treasury does not match the one present on the auction house")]
     AuctionHouseTreasuryMismatch,
+
+    // 6009
+    #[msg("The account address bumps do not match")]
+    BumpMismatch,
 }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -51,9 +51,7 @@ pub mod reward_center {
         listings::update::handler(ctx, update_listing_params)
     }
 
-    pub fn close_listing(
-        ctx: Context<CloseListing>,
-    ) -> Result<()> {
+    pub fn close_listing(ctx: Context<CloseListing>) -> Result<()> {
         listings::close::handler(ctx)
     }
 

--- a/program/src/listings/close/mod.rs
+++ b/program/src/listings/close/mod.rs
@@ -15,7 +15,6 @@ use mpl_auction_house::{
 };
 use solana_program::program::invoke_signed;
 
-
 #[derive(Accounts, Clone)]
 pub struct CloseListing<'info> {
     /// User wallet account.
@@ -111,9 +110,7 @@ pub struct CloseListing<'info> {
     pub auction_house_program: Program<'info, AuctionHouseProgram>,
 }
 
-pub fn handler(
-    ctx: Context<CloseListing>,
-) -> Result<()> {
+pub fn handler(ctx: Context<CloseListing>) -> Result<()> {
     let reward_center = &ctx.accounts.reward_center;
     let auction_house = &ctx.accounts.auction_house;
     let metadata = &ctx.accounts.metadata;

--- a/program/src/offers/close/mod.rs
+++ b/program/src/offers/close/mod.rs
@@ -10,13 +10,15 @@ use mpl_auction_house::{
         AuctioneerCancel as AuctioneerCancelParams, AuctioneerWithdraw as AuctioneerWithdrawParams,
     },
     program::AuctionHouse as AuctionHouseProgram,
-    utils::assert_metadata_valid,
+    utils::{assert_derivation, assert_metadata_valid},
     AuctionHouse, Auctioneer,
 };
 use solana_program::system_program;
 
 use crate::{
     constants::{OFFER, REWARD_CENTER},
+    errors::RewardCenterError,
+    id,
     metaplex_cpi::auction_house::{make_auctioneer_instruction, AuctioneerInstructionArgs},
     state::{Offer, RewardCenter},
 };
@@ -35,17 +37,9 @@ pub struct CloseOffer<'info> {
     pub wallet: Signer<'info>,
 
     /// The Offer config account used for bids
-    #[account(
-        mut,
-        seeds = [
-            OFFER.as_bytes(),
-            wallet.key().as_ref(),
-            metadata.key().as_ref(),
-            reward_center.key().as_ref()
-        ],
-        bump = offer.bump
-    )]
-    pub offer: Box<Account<'info, Offer>>,
+    /// CHECK: Seed check in close offer logic
+    #[account(mut)]
+    pub offer: UncheckedAccount<'info>,
 
     pub treasury_mint: Box<Account<'info, Mint>>,
 
@@ -157,13 +151,25 @@ pub fn handler(
     let metadata = &ctx.accounts.metadata;
     let token_account = &ctx.accounts.token_account;
     let wallet = &ctx.accounts.wallet;
-    let offer = &ctx.accounts.offer;
-    let offer_account_info = offer.to_account_info();
+    let offer_unchecked = &ctx.accounts.offer;
+    let offer_account_info = offer_unchecked.to_account_info();
+    let offer = try_deserialize_offer(&offer_account_info)?;
     let token_size = offer.token_size;
     let buyer_price = offer.price;
     let auction_house_key = auction_house.key();
 
     assert_metadata_valid(metadata, token_account)?;
+    let offer_bump = assert_derivation(
+        &id(),
+        &offer_account_info,
+        &[
+            OFFER.as_bytes(),
+            wallet.key().as_ref(),
+            metadata.key().as_ref(),
+            reward_center.key().as_ref(),
+        ],
+    )?;
+    require_eq!(offer_bump, offer.bump, RewardCenterError::BumpMismatch);
 
     let reward_center_signer_seeds: &[&[&[u8]]] = &[&[
         REWARD_CENTER.as_bytes(),
@@ -238,8 +244,21 @@ pub fn handler(
         reward_center_signer_seeds,
     )?;
 
+    let dest_starting_lamports = wallet.lamports();
+    **wallet.lamports.borrow_mut() = dest_starting_lamports
+        .checked_add(offer_account_info.lamports())
+        .unwrap();
+    **offer_account_info.lamports.borrow_mut() = 0;
+
     offer_account_info.assign(&system_program::id());
     offer_account_info.realloc(0, false)?;
 
     Ok(())
+}
+
+fn try_deserialize_offer(offer: &AccountInfo) -> Result<Offer> {
+    let offer_ref_data = offer.try_borrow_mut_data()?;
+    let mut offer_data: &[u8] = &offer_ref_data;
+
+    Offer::try_deserialize(&mut offer_data)
 }

--- a/program/src/offers/close/mod.rs
+++ b/program/src/offers/close/mod.rs
@@ -13,6 +13,7 @@ use mpl_auction_house::{
     utils::assert_metadata_valid,
     AuctionHouse, Auctioneer,
 };
+use solana_program::system_program;
 
 use crate::{
     constants::{OFFER, REWARD_CENTER},
@@ -42,8 +43,7 @@ pub struct CloseOffer<'info> {
             metadata.key().as_ref(),
             reward_center.key().as_ref()
         ],
-        bump = offer.bump,
-        close = wallet
+        bump = offer.bump
     )]
     pub offer: Box<Account<'info, Offer>>,
 
@@ -158,6 +158,7 @@ pub fn handler(
     let token_account = &ctx.accounts.token_account;
     let wallet = &ctx.accounts.wallet;
     let offer = &ctx.accounts.offer;
+    let offer_account_info = offer.to_account_info();
     let token_size = offer.token_size;
     let buyer_price = offer.price;
     let auction_house_key = auction_house.key();
@@ -236,6 +237,9 @@ pub fn handler(
         &cancel_offer_account_infos,
         reward_center_signer_seeds,
     )?;
+
+    offer_account_info.assign(&system_program::id());
+    offer_account_info.realloc(0, false)?;
 
     Ok(())
 }

--- a/program/tests/reopen_closed_offer.rs
+++ b/program/tests/reopen_closed_offer.rs
@@ -343,18 +343,7 @@ async fn reopned_closed_offer_success() {
     let reopen_offer_ix = create_offer(reopen_offer_accounts, reopen_offer_params);
 
     let tx = Transaction::new_signed_with_payer(
-        &[close_offer_ix],
-        Some(buyer_pubkey),
-        &[&buyer],
-        context.last_blockhash,
-    );
-
-    let tx_response = context.banks_client.process_transaction(tx).await;
-
-    assert!(tx_response.is_ok());
-
-    let tx = Transaction::new_signed_with_payer(
-        &[reopen_offer_ix],
+        &[close_offer_ix, reopen_offer_ix],
         Some(buyer_pubkey),
         &[&buyer],
         context.last_blockhash,

--- a/sdk/reward-center/src/lib.rs
+++ b/sdk/reward-center/src/lib.rs
@@ -9,9 +9,7 @@ use hpl_reward_center::{
     accounts as rewards_accounts,
     execute_sale::ExecuteSaleParams,
     id, instruction,
-    listings::{
-        create::CreateListingParams, update::UpdateListingParams,
-    },
+    listings::{create::CreateListingParams, update::UpdateListingParams},
     offers::{close::CloseOfferParams, create::CreateOfferParams},
     pda::{self, find_listing_address, find_offer_address, find_reward_center_address},
     reward_centers::{create::CreateRewardCenterParams, edit::EditRewardCenterParams},


### PR DESCRIPTION
### Issue
When using anchor closing an account in an instructions and re-open in the next instruction of a transaction results in "address already allocated" error. If switch to vanilla solana for closing out the account and reclaiming the funds encounter a anchor serializer error.

### Fix
Switch to unchecked account for the offer on close_offer and close out & re-claim lamports using vanilla Solana.

### Changes
- Zero out offer account and send funds to the user wallet with vanilla Solana instead of anchor macros
