### PR TITLE
[Fix] Resolve stack access violations

### DIFF
--- a/program/src/offers/create/mod.rs
+++ b/program/src/offers/create/mod.rs
@@ -207,6 +207,12 @@ pub fn handler(
         reward_center_signer_seeds,
     );
 
+    mpl_auction_house::cpi::auctioneer_deposit(
+        deposit_accounts_ctx,
+        escrow_payment_bump,
+        buyer_price,
+    )?;
+
     let public_buy_accounts_ctx = CpiContext::new_with_signer(
         ctx.accounts.auction_house_program.to_account_info(),
         AuctioneerPublicBuy {
@@ -229,12 +235,6 @@ pub fn handler(
         },
         reward_center_signer_seeds,
     );
-
-    mpl_auction_house::cpi::auctioneer_deposit(
-        deposit_accounts_ctx,
-        escrow_payment_bump,
-        buyer_price,
-    )?;
 
     mpl_auction_house::cpi::auctioneer_public_buy(
         public_buy_accounts_ctx,


### PR DESCRIPTION
### Issue
```
[2022-11-15T12:03:43.498708000Z TRACE solana_runtime::system_instruction_processor] keyed_accounts: [KeyedAccount { is_signer: false, is_writable: false, key: 11111111111111111111111111111111, account: RefCell { value: Account { lamports: 1, data.len: 14, owner: NativeLoader1111111111111111111111111111111, executable: true, rent_epoch: 0, data: 73797374656d5f70726f6772616d } } }, KeyedAccount { is_signer: true, is_writable: true, key: FwEqeaRsPGoj4qFfDzWSLRGnLWjSUgaQ9599zDx1fDZm, account: RefCell { value: Account { lamports: 9999995000, data.len: 0, owner: 11111111111111111111111111111111, executable: false, rent_epoch: 0 } } }, KeyedAccount { is_signer: true, is_writable: true, key: 2M51crHUqWFJ4E4kjjiCmPtUzSfcp5HQP8n5gCqDFXR6, account: RefCell { value: Account { lamports: 0, data.len: 0, owner: 11111111111111111111111111111111, executable: false, rent_epoch: 0 } } }]
[2022-11-15T12:03:43.498845000Z DEBUG solana_runtime::message_processor::stable_log] Program 11111111111111111111111111111111 success
[2022-11-15T12:03:43.500589000Z DEBUG solana_runtime::message_processor::stable_log] Program RwDDvPp7ta9qqUwxbBfShsNreBaSsKvFcHzMxfBC3Ki consumed 37234 of 200000 compute units
[2022-11-15T12:03:43.500622000Z DEBUG solana_runtime::message_processor::stable_log] Program failed to complete: Access violation in stack frame 5 at address 0x200005ff8 of size 8 by instruction #17030
[2022-11-15T12:03:43.500633000Z DEBUG solana_runtime::message_processor::stable_log] Program RwDDvPp7ta9qqUwxbBfShsNreBaSsKvFcHzMxfBC3Ki failed: Program failed to complete
```

### Changes
- Declare context and make CPI call for deposit then declare context and make CPI call for public buy.