### PR TITLE
[Fix] Passing remaining accounts to execute_sale for accept_offer and buy_listing

### DIFF
--- a/program/src/listings/buy/mod.rs
+++ b/program/src/listings/buy/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     constants::{LISTING, REWARD_CENTER},
     errors::RewardCenterError,
-    metaplex_cpi::auction_house::{make_auctioneer_instruction, AuctioneerInstructionArgs},
     state::{Listing, RewardCenter},
 };
 use anchor_lang::{
@@ -303,7 +302,6 @@ pub fn handler<'info>(
     let auction_house = &ctx.accounts.auction_house;
     let token_account = &ctx.accounts.token_account;
     let listing = &ctx.accounts.listing;
-    let remaining_accounts = ctx.remaining_accounts;
 
     let listing_price = listing.price;
     let token_size = listing.token_size;
@@ -370,57 +368,70 @@ pub fn handler<'info>(
         token_size,
     )?;
 
-    let (execute_sale_ix, execute_sale_account_infos) =
-        make_auctioneer_instruction(AuctioneerInstructionArgs {
-            accounts: AuctioneerExecuteSale {
-                buyer: ctx.accounts.buyer.to_account_info(),
-                seller: ctx.accounts.seller.to_account_info(),
-                token_account: ctx.accounts.token_account.to_account_info(),
-                ah_auctioneer_pda: ctx.accounts.ah_auctioneer_pda.to_account_info(),
-                auction_house: ctx.accounts.auction_house.to_account_info(),
-                auction_house_fee_account: ctx.accounts.auction_house_fee_account.to_account_info(),
-                auction_house_treasury: ctx.accounts.auction_house_treasury.to_account_info(),
-                buyer_receipt_token_account: ctx
-                    .accounts
-                    .buyer_receipt_token_account
-                    .to_account_info(),
-                seller_payment_receipt_account: ctx
-                    .accounts
-                    .seller_payment_receipt_account
-                    .to_account_info(),
-                buyer_trade_state: ctx.accounts.buyer_trade_state.to_account_info(),
-                free_trade_state: ctx.accounts.free_seller_trade_state.to_account_info(),
-                seller_trade_state: ctx.accounts.seller_trade_state.to_account_info(),
-                escrow_payment_account: ctx.accounts.escrow_payment_account.to_account_info(),
-                program_as_signer: ctx.accounts.program_as_signer.to_account_info(),
-                authority: ctx.accounts.authority.to_account_info(),
-                metadata: ctx.accounts.metadata.to_account_info(),
-                token_mint: ctx.accounts.token_mint.to_account_info(),
-                treasury_mint: ctx.accounts.treasury_mint.to_account_info(),
-                auctioneer_authority: ctx.accounts.reward_center.to_account_info(),
-                system_program: ctx.accounts.system_program.to_account_info(),
-                token_program: ctx.accounts.token_program.to_account_info(),
-                ata_program: ctx.accounts.ata_program.to_account_info(),
-                rent: ctx.accounts.rent.to_account_info(),
-            },
-            instruction_data: AuctioneerExecuteSaleParams {
-                escrow_payment_bump,
-                program_as_signer_bump,
-                token_size,
-                buyer_price: listing_price,
-                _free_trade_state_bump: free_trade_state_bump,
-            }
-            .data(),
-            auctioneer_authority: ctx.accounts.reward_center.key(),
-        });
+    let cpi_program = ctx.accounts.auction_house_program.to_account_info();
+    let cpi_accounts = AuctioneerExecuteSale {
+        buyer: ctx.accounts.buyer.to_account_info(),
+        seller: ctx.accounts.seller.to_account_info(),
+        token_account: ctx.accounts.token_account.to_account_info(),
+        ah_auctioneer_pda: ctx.accounts.ah_auctioneer_pda.to_account_info(),
+        auction_house: ctx.accounts.auction_house.to_account_info(),
+        auction_house_fee_account: ctx.accounts.auction_house_fee_account.to_account_info(),
+        auction_house_treasury: ctx.accounts.auction_house_treasury.to_account_info(),
+        buyer_receipt_token_account: ctx.accounts.buyer_receipt_token_account.to_account_info(),
+        seller_payment_receipt_account: ctx
+            .accounts
+            .seller_payment_receipt_account
+            .to_account_info(),
+        buyer_trade_state: ctx.accounts.buyer_trade_state.to_account_info(),
+        free_trade_state: ctx.accounts.free_seller_trade_state.to_account_info(),
+        seller_trade_state: ctx.accounts.seller_trade_state.to_account_info(),
+        escrow_payment_account: ctx.accounts.escrow_payment_account.to_account_info(),
+        program_as_signer: ctx.accounts.program_as_signer.to_account_info(),
+        authority: ctx.accounts.authority.to_account_info(),
+        metadata: ctx.accounts.metadata.to_account_info(),
+        token_mint: ctx.accounts.token_mint.to_account_info(),
+        treasury_mint: ctx.accounts.treasury_mint.to_account_info(),
+        auctioneer_authority: ctx.accounts.reward_center.to_account_info(),
+        system_program: ctx.accounts.system_program.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+        ata_program: ctx.accounts.ata_program.to_account_info(),
+        rent: ctx.accounts.rent.to_account_info(),
+    };
 
-    // Append the remaining accounts to execute_sale account infos which will be the creators accounts for paying royalties
-    let account_infos = execute_sale_account_infos
+    let execute_sale_data = AuctioneerExecuteSaleParams {
+        escrow_payment_bump,
+        program_as_signer_bump,
+        token_size,
+        buyer_price: listing_price,
+        _free_trade_state_bump: free_trade_state_bump,
+    };
+
+    let mut cpi_account_metas: Vec<AccountMeta> = cpi_accounts
+        .to_account_metas(None)
         .into_iter()
-        .chain(remaining_accounts.iter().cloned())
-        .collect::<Vec<AccountInfo>>();
+        .zip(cpi_accounts.to_account_infos())
+        .map(|mut pair| {
+            pair.0.is_signer = pair.1.is_signer;
+            if pair.0.pubkey == ctx.accounts.reward_center.key() {
+                pair.0.is_signer = true;
+            }
+            pair.0
+        })
+        .collect();
 
-    invoke_signed(&execute_sale_ix, &account_infos, reward_center_signer_seeds)?;
+    cpi_account_metas.append(&mut ctx.remaining_accounts.to_vec().to_account_metas(None));
+
+    let execute_sale_ix = solana_program::instruction::Instruction {
+        program_id: cpi_program.key(),
+        accounts: cpi_account_metas,
+        data: execute_sale_data.data(),
+    };
+
+    invoke_signed(
+        &execute_sale_ix,
+        &cpi_accounts.to_account_infos(),
+        reward_center_signer_seeds,
+    )?;
 
     let (seller_payout, buyer_payout) = reward_center.payouts(listing_price)?;
 

--- a/program/src/offers/accept/mod.rs
+++ b/program/src/offers/accept/mod.rs
@@ -290,7 +290,6 @@ pub fn handler<'info>(
     let reward_center = &ctx.accounts.reward_center;
     let token_account = &ctx.accounts.token_account;
     let metadata = &ctx.accounts.metadata;
-    let remaining_accounts = ctx.remaining_accounts;
     let token_size = offer.token_size;
     let buyer_price = offer.price;
 
@@ -339,57 +338,70 @@ pub fn handler<'info>(
         reward_center_signer_seeds,
     )?;
 
-    let (execute_sale_ix, execute_sale_account_infos) =
-        make_auctioneer_instruction(AuctioneerInstructionArgs {
-            accounts: AuctioneerExecuteSale {
-                buyer: ctx.accounts.buyer.to_account_info(),
-                seller: ctx.accounts.seller.to_account_info(),
-                token_account: ctx.accounts.token_account.to_account_info(),
-                ah_auctioneer_pda: ctx.accounts.ah_auctioneer_pda.to_account_info(),
-                auction_house: ctx.accounts.auction_house.to_account_info(),
-                auction_house_fee_account: ctx.accounts.auction_house_fee_account.to_account_info(),
-                auction_house_treasury: ctx.accounts.auction_house_treasury.to_account_info(),
-                buyer_receipt_token_account: ctx
-                    .accounts
-                    .buyer_receipt_token_account
-                    .to_account_info(),
-                seller_payment_receipt_account: ctx
-                    .accounts
-                    .seller_payment_receipt_account
-                    .to_account_info(),
-                buyer_trade_state: ctx.accounts.buyer_trade_state.to_account_info(),
-                free_trade_state: ctx.accounts.free_seller_trade_state.to_account_info(),
-                seller_trade_state: ctx.accounts.seller_trade_state.to_account_info(),
-                escrow_payment_account: ctx.accounts.escrow_payment_account.to_account_info(),
-                program_as_signer: ctx.accounts.program_as_signer.to_account_info(),
-                authority: ctx.accounts.authority.to_account_info(),
-                metadata: ctx.accounts.metadata.to_account_info(),
-                token_mint: ctx.accounts.token_mint.to_account_info(),
-                treasury_mint: ctx.accounts.treasury_mint.to_account_info(),
-                auctioneer_authority: ctx.accounts.reward_center.to_account_info(),
-                system_program: ctx.accounts.system_program.to_account_info(),
-                token_program: ctx.accounts.token_program.to_account_info(),
-                ata_program: ctx.accounts.ata_program.to_account_info(),
-                rent: ctx.accounts.rent.to_account_info(),
-            },
-            instruction_data: AuctioneerExecuteSaleParams {
-                escrow_payment_bump,
-                program_as_signer_bump,
-                token_size,
-                buyer_price,
-                _free_trade_state_bump: free_trade_state_bump,
-            }
-            .data(),
-            auctioneer_authority: ctx.accounts.reward_center.key(),
-        });
+    let cpi_program = ctx.accounts.auction_house_program.to_account_info();
+    let cpi_accounts = AuctioneerExecuteSale {
+        buyer: ctx.accounts.buyer.to_account_info(),
+        seller: ctx.accounts.seller.to_account_info(),
+        token_account: ctx.accounts.token_account.to_account_info(),
+        ah_auctioneer_pda: ctx.accounts.ah_auctioneer_pda.to_account_info(),
+        auction_house: ctx.accounts.auction_house.to_account_info(),
+        auction_house_fee_account: ctx.accounts.auction_house_fee_account.to_account_info(),
+        auction_house_treasury: ctx.accounts.auction_house_treasury.to_account_info(),
+        buyer_receipt_token_account: ctx.accounts.buyer_receipt_token_account.to_account_info(),
+        seller_payment_receipt_account: ctx
+            .accounts
+            .seller_payment_receipt_account
+            .to_account_info(),
+        buyer_trade_state: ctx.accounts.buyer_trade_state.to_account_info(),
+        free_trade_state: ctx.accounts.free_seller_trade_state.to_account_info(),
+        seller_trade_state: ctx.accounts.seller_trade_state.to_account_info(),
+        escrow_payment_account: ctx.accounts.escrow_payment_account.to_account_info(),
+        program_as_signer: ctx.accounts.program_as_signer.to_account_info(),
+        authority: ctx.accounts.authority.to_account_info(),
+        metadata: ctx.accounts.metadata.to_account_info(),
+        token_mint: ctx.accounts.token_mint.to_account_info(),
+        treasury_mint: ctx.accounts.treasury_mint.to_account_info(),
+        auctioneer_authority: ctx.accounts.reward_center.to_account_info(),
+        system_program: ctx.accounts.system_program.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+        ata_program: ctx.accounts.ata_program.to_account_info(),
+        rent: ctx.accounts.rent.to_account_info(),
+    };
 
-    // Append the remaining accounts to execute_sale account infos which will be the creators accounts for paying royalties
-    let account_infos = execute_sale_account_infos
+    let execute_sale_data = AuctioneerExecuteSaleParams {
+        escrow_payment_bump,
+        program_as_signer_bump,
+        token_size,
+        buyer_price,
+        _free_trade_state_bump: free_trade_state_bump,
+    };
+
+    let mut cpi_account_metas: Vec<AccountMeta> = cpi_accounts
+        .to_account_metas(None)
         .into_iter()
-        .chain(remaining_accounts.iter().cloned())
-        .collect::<Vec<AccountInfo>>();
+        .zip(cpi_accounts.to_account_infos())
+        .map(|mut pair| {
+            pair.0.is_signer = pair.1.is_signer;
+            if pair.0.pubkey == ctx.accounts.reward_center.key() {
+                pair.0.is_signer = true;
+            }
+            pair.0
+        })
+        .collect();
 
-    invoke_signed(&execute_sale_ix, &account_infos, reward_center_signer_seeds)?;
+    cpi_account_metas.append(&mut ctx.remaining_accounts.to_vec().to_account_metas(None));
+
+    let execute_sale_ix = solana_program::instruction::Instruction {
+        program_id: cpi_program.key(),
+        accounts: cpi_account_metas,
+        data: execute_sale_data.data(),
+    };
+
+    invoke_signed(
+        &execute_sale_ix,
+        &cpi_accounts.to_account_infos(),
+        reward_center_signer_seeds,
+    )?;
 
     let (seller_payout, buyer_payout) = reward_center.payouts(buyer_price)?;
 

--- a/program/tests/buy_listing.rs
+++ b/program/tests/buy_listing.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
+use anchor_client::solana_sdk::{
+    instruction::AccountMeta, pubkey::Pubkey, signature::Signer, transaction::Transaction,
+};
 use hpl_reward_center::{
     pda::{find_listing_address, find_reward_center_address},
     reward_centers,
@@ -51,7 +53,6 @@ async fn buy_listing_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {
@@ -308,7 +309,11 @@ async fn buy_listing_success() {
         reward_mint: reward_mint_pubkey,
     };
 
-    let buy_listing_ix = buy_listing(buy_listing_accounts, buy_listing_params);
+    let buy_listing_ix = buy_listing(
+        buy_listing_accounts,
+        buy_listing_params,
+        vec![AccountMeta::new(metadata_owner_address, false)],
+    );
 
     let tx = Transaction::new_signed_with_payer(
         &[

--- a/program/tests/close_listing.rs
+++ b/program/tests/close_listing.rs
@@ -51,7 +51,6 @@ async fn close_listing_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {

--- a/program/tests/close_offer.rs
+++ b/program/tests/close_offer.rs
@@ -42,7 +42,6 @@ async fn close_offer_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {

--- a/program/tests/create_listing.rs
+++ b/program/tests/create_listing.rs
@@ -46,7 +46,6 @@ async fn create_listing_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {

--- a/program/tests/create_offer.rs
+++ b/program/tests/create_offer.rs
@@ -50,7 +50,6 @@ async fn create_offer_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {

--- a/program/tests/reopen_closed_listing.rs
+++ b/program/tests/reopen_closed_listing.rs
@@ -50,7 +50,6 @@ async fn reopen_closed_listing_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {

--- a/program/tests/reopen_closed_offer.rs
+++ b/program/tests/reopen_closed_offer.rs
@@ -50,7 +50,6 @@ async fn reopned_closed_offer_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {

--- a/program/tests/reopen_purchased_listing.rs
+++ b/program/tests/reopen_purchased_listing.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
+use anchor_client::solana_sdk::{
+    instruction::AccountMeta, pubkey::Pubkey, signature::Signer, transaction::Transaction,
+};
 use hpl_reward_center::{
     pda::{find_listing_address, find_reward_center_address},
     reward_centers,
@@ -51,7 +53,6 @@ async fn reopen_purchased_listing_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {
@@ -309,7 +310,11 @@ async fn reopen_purchased_listing_success() {
         reward_mint: reward_mint_pubkey,
     };
 
-    let accpet_offer_ix = buy_listing(buy_listing_accounts, buy_listing_data);
+    let accpet_offer_ix = buy_listing(
+        buy_listing_accounts,
+        buy_listing_data,
+        vec![AccountMeta::new(metadata_owner_address, false)],
+    );
 
     let tx = Transaction::new_signed_with_payer(
         &[

--- a/program/tests/reopen_purchased_offer.rs
+++ b/program/tests/reopen_purchased_offer.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
+use anchor_client::solana_sdk::{
+    instruction::AccountMeta, pubkey::Pubkey, signature::Signer, transaction::Transaction,
+};
 use hpl_reward_center::{
     pda::{find_listing_address, find_reward_center_address},
     reward_centers,
@@ -51,7 +53,6 @@ async fn reopen_purchased_listing_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {
@@ -308,7 +309,11 @@ async fn reopen_purchased_listing_success() {
         reward_mint: reward_mint_pubkey,
     };
 
-    let accept_offer = accept_offer(accept_offer_accounts, accept_offer_data);
+    let accept_offer = accept_offer(
+        accept_offer_accounts,
+        accept_offer_data,
+        vec![AccountMeta::new(metadata_owner_address, false)],
+    );
 
     let tx = Transaction::new_signed_with_payer(
         &[

--- a/program/tests/reward_center_test/fixtures/metadata.rs
+++ b/program/tests/reward_center_test/fixtures/metadata.rs
@@ -10,7 +10,6 @@ pub struct Params<'a> {
     pub name: &'a str,
     pub symbol: &'a str,
     pub uri: &'a str,
-    pub creators: Option<Vec<Creator>>,
     pub seller_fee_basis_points: u16,
     pub is_mutable: bool,
     pub collection: Option<Collection>,
@@ -23,7 +22,6 @@ pub async fn create<'a>(
         name,
         symbol,
         uri,
-        creators,
         seller_fee_basis_points,
         is_mutable,
         collection,
@@ -38,6 +36,12 @@ pub async fn create<'a>(
     airdrop(context, owner_pubkey, airdrop_amount)
         .await
         .unwrap();
+
+    let creators = Some(vec![Creator {
+        address: *owner_pubkey,
+        share: 100,
+        verified: false,
+    }]);
 
     test_metadata
         .create_v2(

--- a/program/tests/update_listing.rs
+++ b/program/tests/update_listing.rs
@@ -51,7 +51,6 @@ async fn update_listing_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {

--- a/program/tests/update_offer.rs
+++ b/program/tests/update_offer.rs
@@ -51,7 +51,6 @@ async fn create_offer_success() {
             name: "Test",
             symbol: "TST",
             uri: "https://nfts.exp.com/1.json",
-            creators: None,
             seller_fee_basis_points: 10,
             is_mutable: false,
             collection: Some(Collection {

--- a/sdk/reward-center/src/lib.rs
+++ b/sdk/reward-center/src/lib.rs
@@ -3,7 +3,7 @@ pub mod args;
 
 use accounts::*;
 use anchor_client::solana_sdk::{instruction::Instruction, pubkey::Pubkey, system_program, sysvar};
-use anchor_lang::{prelude::*, InstructionData};
+use anchor_lang::{prelude::*, solana_program::instruction::AccountMeta, InstructionData};
 use args::*;
 use hpl_reward_center::{
     accounts as rewards_accounts, id, instruction,
@@ -403,6 +403,7 @@ pub fn buy_listing(
         price,
         reward_mint,
     }: BuyListingData,
+    creators: Vec<AccountMeta>,
 ) -> Instruction {
     let (reward_center, _) = find_reward_center_address(&auction_house);
     let (listing, _) = find_listing_address(&seller, &metadata, &reward_center);
@@ -498,7 +499,7 @@ pub fn buy_listing(
 
     Instruction {
         program_id: id(),
-        accounts,
+        accounts: accounts.into_iter().chain(creators).collect(),
         data,
     }
 }
@@ -521,6 +522,7 @@ pub fn accept_offer(
         price,
         reward_mint,
     }: AcceptOfferData,
+    creators: Vec<AccountMeta>,
 ) -> Instruction {
     let (reward_center, _) = find_reward_center_address(&auction_house);
     let (offer, _) = find_offer_address(&buyer, &metadata, &reward_center);
@@ -614,7 +616,7 @@ pub fn accept_offer(
 
     Instruction {
         program_id: id(),
-        accounts,
+        accounts: accounts.into_iter().chain(creators).collect(),
         data,
     }
 }


### PR DESCRIPTION
### Issue
CPI call to execute_sale failed when metadata has creators

### Fix
- Pass extra accounts to the CPI by referencing [auctioneer execute_sale](https://github.com/metaplex-foundation/metaplex-program-library/blob/master/auctioneer/program/src/execute_sale/mod.rs)