### PR TITLE
[Fix] Append remaining accounts to account info

### DIFF
--- a/program/src/metaplex_cpi/auction_house/mod.rs
+++ b/program/src/metaplex_cpi/auction_house/mod.rs
@@ -17,7 +17,7 @@ pub fn make_auctioneer_instruction<'c, 'info, T: ToAccountInfos<'info> + ToAccou
         remaining_accounts,
     }: AuctioneerInstructionArgs<'c, 'info, T>,
 ) -> (Instruction, Vec<AccountInfo<'info>>) {
-    let account_infos = accounts.to_account_infos();
+    let mut account_infos = accounts.to_account_infos();
 
     let mut accounts: Vec<AccountMeta> = accounts
         .to_account_metas(None)
@@ -34,6 +34,7 @@ pub fn make_auctioneer_instruction<'c, 'info, T: ToAccountInfos<'info> + ToAccou
 
     if let Some(remaining_accounts) = remaining_accounts {
         accounts.append(&mut remaining_accounts.to_vec().to_account_metas(None));
+        account_infos.append(&mut remaining_accounts.to_vec());
     };
 
     (


### PR DESCRIPTION
### Issue
The original account_info without the remaining accounts was being returned by the helper and causing the invok_signed to have mismatch in the number of accounts.

### Fix
Adjust the account_infos as well when remaining accounts are provided to the helper.