### PR TITLE
feat: add address table look up and withdraw auction house treasury commands

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2363,6 +2363,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.13",
+ "solana-address-lookup-table-program",
  "solana-client",
  "solana-program",
  "solana-sdk",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,7 @@ retry = "2.0.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
 serde_yaml = "0.9.13"
+solana-address-lookup-table-program = "1.9.28"
 solana-client = "1.9.28"
 solana-program = "1.9.28"
 solana-sdk = "1.9.28"

--- a/cli/src/commands/create.rs
+++ b/cli/src/commands/create.rs
@@ -220,7 +220,7 @@ pub fn process_create_reward_center(
 
     if auction_house.is_none() {
         info!(
-            "Auction house account not passed. Creating a new auction house with default parameters"
+            "Auction house account not passed. Creating a new auction house with default parameters of address {}", auction_house_pubkey.to_string()
         );
 
         let create_auction_house_ix =

--- a/cli/src/commands/create.rs
+++ b/cli/src/commands/create.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, Context, Result as AnyhowResult};
+use anyhow::{bail, Context, Result as AnyhowResult};
 use hpl_reward_center::pda::find_reward_center_address;
 use hpl_reward_center_sdk::accounts::CreateRewardCenterAccounts;
 use hpl_reward_center_sdk::create_reward_center;
@@ -315,7 +315,7 @@ pub fn process_create_reward_center(
         },
         Err(error) => {
             error!("{:?}", error);
-            return Err(anyhow!("ailed to send the transaction"));
+            bail!("Failed to send the transaction")
         },
     };
 

--- a/cli/src/commands/create.rs
+++ b/cli/src/commands/create.rs
@@ -17,8 +17,9 @@ use mpl_auction_house::{
     state::AuthorityScope,
 };
 use mpl_auction_house_sdk::{
-    create_auction_house, delegate_auctioneer, CreateAuctionHouseAccounts, CreateAuctionHouseData,
-    DelegateAuctioneerAccounts, DelegateAuctioneerData,
+    accounts::{CreateAuctionHouseAccounts, DelegateAuctioneerAccounts},
+    args::{CreateAuctionHouseData, DelegateAuctioneerData},
+    create_auction_house, delegate_auctioneer,
 };
 use solana_client::rpc_client::RpcClient;
 use solana_program::{

--- a/cli/src/commands/create_atl.rs
+++ b/cli/src/commands/create_atl.rs
@@ -1,0 +1,119 @@
+use std::{path::PathBuf, str::FromStr, vec};
+
+use crate::config::{parse_keypair, parse_solana_configuration};
+use anchor_lang::{prelude::Pubkey, AnchorDeserialize};
+use anyhow::{bail, Context, Result as AnyhowResult};
+use hpl_reward_center::{pda::find_reward_center_address, state::RewardCenter};
+use log::{error, info};
+use mpl_auction_house::{
+    pda::{find_auctioneer_pda, find_program_as_signer_address},
+    AuctionHouse,
+};
+use solana_address_lookup_table_program::instruction::{create_lookup_table, extend_lookup_table};
+use solana_client::rpc_client::RpcClient;
+use solana_program::instruction::Instruction;
+use solana_sdk::{commitment_config::CommitmentConfig, signer::Signer, transaction::Transaction};
+use spl_associated_token_account::get_associated_token_address;
+
+/// # Errors
+///
+/// Will return `Err` if the following happens
+/// 1. Auction House/Keypair Path fails to parse/open
+/// 2. Transaction errors due to validation
+/// 3. RPC Errors if timed out
+pub fn process_create_address_table_lookup(
+    client: &RpcClient,
+    keypair_path: &Option<PathBuf>,
+    auction_house: &str,
+) -> AnyhowResult<()> {
+    let solana_options = parse_solana_configuration()?;
+
+    let keypair = parse_keypair(keypair_path, &solana_options)?;
+
+    let auction_house_pubkey = Pubkey::from_str(auction_house)
+        .context("Failed to parse Pubkey from auction_house string")?;
+
+    let auction_house_data = client
+        .get_account_data(&auction_house_pubkey)
+        .context("Failed to get auction house data")?;
+
+    let AuctionHouse {
+        authority: auction_house_authority,
+        treasury_mint,
+        auction_house_fee_account,
+        auction_house_treasury,
+        ..
+    } = AuctionHouse::deserialize(&mut &auction_house_data[8..])?;
+
+    let (reward_center_pubkey, _) = find_reward_center_address(&auction_house_pubkey);
+
+    let reward_center_data = client
+        .get_account_data(&reward_center_pubkey)
+        .context("Failed to get reward center data")?;
+
+    let RewardCenter { token_mint, .. } = RewardCenter::deserialize(&mut &reward_center_data[8..])?;
+
+    if auction_house_authority.ne(&keypair.pubkey()) {
+        error!("Given authority does not match with auction house authority");
+        bail!("Auction authority address mismatch")
+    }
+
+    let reward_center_reward_token_account =
+        get_associated_token_address(&reward_center_pubkey, &token_mint);
+
+    let addresses = vec![
+        auction_house_pubkey,
+        find_auctioneer_pda(&auction_house_pubkey, &auction_house_authority).0,
+        reward_center_pubkey,
+        auction_house_treasury,
+        auction_house_fee_account,
+        auction_house_authority,
+        spl_associated_token_account::id(),
+        // token_account,
+        treasury_mint,
+        reward_center_reward_token_account,
+        find_program_as_signer_address().0,
+    ];
+
+    let recent_slot = client
+        .get_slot_with_commitment(CommitmentConfig::finalized())
+        .unwrap();
+
+    let (create_address_lookup_table_ix, address_lookup_table_pubkey) =
+        create_lookup_table(keypair.pubkey(), keypair.pubkey(), recent_slot);
+
+    let extend_lookup_table_ix = extend_lookup_table(
+        address_lookup_table_pubkey,
+        keypair.pubkey(),
+        keypair.pubkey(),
+        addresses,
+    );
+
+    let instructions: Vec<Instruction> =
+        vec![create_address_lookup_table_ix, extend_lookup_table_ix];
+
+    let latest_blockhash = client.get_latest_blockhash().unwrap();
+    let tx_hash = client.send_and_confirm_transaction(&Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&keypair.pubkey()),
+        &[&keypair],
+        latest_blockhash,
+    ));
+
+    match tx_hash {
+        Ok(signature) => {
+            info!("Created in tx: {:?}", &signature);
+        },
+        Err(error) => {
+            error!("{:?}", error);
+            bail!("Failed to send the transaction")
+        },
+    };
+
+    info!(
+        "Address table lookup created successfully. Address: {}",
+        address_lookup_table_pubkey.to_string()
+    );
+
+    Ok(())
+}

--- a/cli/src/commands/create_atl.rs
+++ b/cli/src/commands/create_atl.rs
@@ -77,7 +77,7 @@ pub fn process_create_address_table_lookup(
 
     let recent_slot = client
         .get_slot_with_commitment(CommitmentConfig::finalized())
-        .unwrap();
+        .context("Failed to fetch recent slot")?;
 
     let (create_address_lookup_table_ix, address_lookup_table_pubkey) =
         create_lookup_table(keypair.pubkey(), keypair.pubkey(), recent_slot);

--- a/cli/src/commands/edit.rs
+++ b/cli/src/commands/edit.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, Context, Result as AnyhowResult};
+use anyhow::{bail, Context, Result as AnyhowResult};
 use hpl_reward_center::{
     reward_centers::edit::EditRewardCenterParams,
     state::{PayoutOperation, RewardRules},
@@ -59,7 +59,7 @@ pub fn process_edit_reward_center(
         }
     } else {
         error!("Update reward center config doesn't exist");
-        return Err(anyhow!("Update config missing"));
+        bail!("Update config missing")
     };
 
     let edit_reward_center_ix = edit_reward_center(

--- a/cli/src/commands/fetch_balance.rs
+++ b/cli/src/commands/fetch_balance.rs
@@ -12,6 +12,9 @@ use spl_associated_token_account::get_associated_token_address;
 /// Will return `Err` if the following happens
 /// 1. Reward center address fails to parse
 /// 2. Reward center/rewards mint/reward center token account account does not exist
+/// # Panics
+///
+/// Will panic if treasury balance amount does not parse
 pub fn process_fetch_reward_center_treasury_balance(
     client: &RpcClient,
     reward_center: &str,
@@ -34,9 +37,9 @@ pub fn process_fetch_reward_center_treasury_balance(
         .get_token_account_balance(&reward_center_rewards_token_account)
         .context("Unable to fetch reward center rewards balacne")?;
 
-    let token_balance = token_res
-        .ui_amount
-        .unwrap_or_else(|| (token_res.amount.parse::<f64>().unwrap()) / token_res.decimals as f64);
+    let token_balance = token_res.ui_amount.unwrap_or_else(|| {
+        (token_res.amount.parse::<f64>().unwrap()) / f64::from(token_res.decimals)
+    });
 
     info!(
         "Reward center rewards mint address: {}",

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,10 +1,12 @@
 pub mod create;
+pub mod create_atl;
 pub mod edit;
 pub mod fetch_balance;
 pub mod fetch_state;
 pub mod fund;
 
 pub use create::*;
+pub use create_atl::*;
 pub use edit::*;
 pub use fetch_balance::*;
 pub use fetch_state::*;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod edit;
 pub mod fetch_balance;
 pub mod fetch_state;
 pub mod fund;
+pub mod withdraw_auction_house;
 
 pub use create::*;
 pub use create_atl::*;
@@ -11,3 +12,4 @@ pub use edit::*;
 pub use fetch_balance::*;
 pub use fetch_state::*;
 pub use fund::*;
+pub use withdraw_auction_house::*;

--- a/cli/src/commands/withdraw_auction_house.rs
+++ b/cli/src/commands/withdraw_auction_house.rs
@@ -53,7 +53,6 @@ pub fn process_withdraw_auction_house_treasury(
 
     let amount_to_withdraw = if treasury_mint.eq(&spl_token::native_mint::id()) {
         let rent_exemption_lamports = client.get_minimum_balance_for_rent_exemption(0)?;
-        info!("Deducting the rent amount from the withdrawal value");
 
         let auction_house_treasury_address =
             find_auction_house_treasury_address(&auction_house_pubkey).0;

--- a/cli/src/commands/withdraw_auction_house.rs
+++ b/cli/src/commands/withdraw_auction_house.rs
@@ -1,0 +1,81 @@
+use std::{path::PathBuf, str::FromStr};
+
+use anchor_lang::AnchorDeserialize;
+use anyhow::{Context, Result as AnyhowResult};
+use log::info;
+use mpl_auction_house::AuctionHouse;
+use mpl_auction_house_sdk::{accounts::WithdrawFromTreasuryAccounts, withdraw_from_treasury};
+use retry::{delay::Exponential, retry};
+use solana_client::rpc_client::RpcClient;
+use solana_program::{instruction::Instruction, program_pack::Pack, pubkey::Pubkey};
+use solana_sdk::{signer::Signer, transaction::Transaction};
+use spl_token::state::Mint;
+
+use crate::config::{parse_keypair, parse_solana_configuration};
+
+/// # Errors
+///
+/// Will return `Err` if the following happens
+/// 1. Auction house fails to parse
+/// 2. Withdrawal amount is greater than the treasury balance
+pub fn process_withdraw_auction_house_treasury(
+    client: &RpcClient,
+    keypair_path: &Option<PathBuf>,
+    auction_house: &str,
+    amount: u64,
+) -> AnyhowResult<()> {
+    let solana_options = parse_solana_configuration()?;
+
+    let keypair = parse_keypair(keypair_path, &solana_options)?;
+
+    let auction_house_pubkey = Pubkey::from_str(auction_house)
+        .context("Failed to parse Pubkey from auction house string")?;
+
+    info!("Getting auction house data");
+    let auction_house_data = client
+        .get_account_data(&auction_house_pubkey)
+        .context("Failed to get auction house data")?;
+
+    let AuctionHouse {
+        treasury_withdrawal_destination,
+        treasury_mint,
+        authority,
+        ..
+    } = AuctionHouse::deserialize(&mut &auction_house_data[8..])?;
+
+    let token_mint_data = client.get_account_data(&treasury_mint)?;
+
+    let Mint { decimals, .. } = Mint::unpack(&token_mint_data[..])?;
+
+    let amount_to_withdraw_with_decimals =
+        amount.saturating_mul(10u64.saturating_pow(decimals.into()));
+
+    let instructions: Vec<Instruction> = vec![withdraw_from_treasury(
+        WithdrawFromTreasuryAccounts {
+            treasury_mint,
+            treasury_withdrawal_destination,
+            auction_house: auction_house_pubkey,
+            authority,
+        },
+        amount_to_withdraw_with_decimals,
+    )];
+
+    let latest_blockhash = client.get_latest_blockhash()?;
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&keypair.pubkey()),
+        &[&keypair],
+        latest_blockhash,
+    );
+
+    info!("Withdrawing {} tokens from auction house", amount);
+
+    let tx_hash = retry(
+        Exponential::from_millis_with_factor(250, 2.0).take(3),
+        || client.send_and_confirm_transaction(&transaction),
+    )?;
+
+    info!("Withdrawal complete. Tx hash {}", tx_hash);
+
+    Ok(())
+}

--- a/cli/src/commands/withdraw_reward_center.rs
+++ b/cli/src/commands/withdraw_reward_center.rs
@@ -29,7 +29,6 @@ pub fn process_withdraw_reward_center(
     let solana_options = parse_solana_configuration()?;
 
     let keypair = parse_keypair(keypair_path, &solana_options)?;
-    let token_program = spl_token::id();
 
     let reward_center_pubkey = Pubkey::from_str(reward_center)
         .context("Failed to parse Pubkey from mint rewards string")?;
@@ -46,9 +45,6 @@ pub fn process_withdraw_reward_center(
     let token_mint_data = client.get_account_data(&token_mint)?;
 
     let Mint { decimals, .. } = Mint::unpack(&token_mint_data[..])?;
-
-    let caller_reward_mint_token_account =
-        get_associated_token_address(&keypair.pubkey(), &token_mint);
 
     let reward_center_reward_mint_token_account =
         get_associated_token_address(&reward_center_pubkey, &token_mint);
@@ -74,7 +70,7 @@ pub fn process_withdraw_reward_center(
                 }
 
                 vec![withdraw_reward_center_funds(
-                    WithdrawRewardCenterAccounts {
+                    WithdrawRewardCenterFundsAccounts {
                         wallet: keypair.pubkey(),
                         rewards_mint: token_mint,
                         auction_house,

--- a/cli/src/commands/withdraw_reward_center.rs
+++ b/cli/src/commands/withdraw_reward_center.rs
@@ -20,7 +20,7 @@ use crate::config::{parse_keypair, parse_solana_configuration};
 /// Will return `Err` if the following happens
 /// 1. Reward center address fails to parse
 /// 2. Withdrawal amount is greater than the treasury balance
-pub fn process_withdraw_reward_center(
+pub fn process_withdraw_reward_center_treasury(
     client: &RpcClient,
     keypair_path: &Option<PathBuf>,
     reward_center: &str,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,9 +14,9 @@ use clap::Parser;
 use log::{error, info, warn};
 use reward_center_cli::{
     commands::{
-        process_create_reward_center, process_edit_reward_center,
-        process_fetch_reward_center_state, process_fetch_reward_center_treasury_balance,
-        process_fund_reward_center,
+        process_create_address_table_lookup, process_create_reward_center,
+        process_edit_reward_center, process_fetch_reward_center_state,
+        process_fetch_reward_center_treasury_balance, process_fund_reward_center,
     },
     config::parse_solana_configuration,
     constants::PUBLIC_RPC_URLS,
@@ -84,6 +84,11 @@ fn run() -> Result<()> {
             &auction_house,
             &mint_rewards,
         )?,
+
+        Command::CreateAddressTable {
+            auction_house,
+            keypair,
+        } => process_create_address_table_lookup(&client, &keypair, &auction_house)?,
 
         Command::Edit {
             keypair,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,7 @@ use reward_center_cli::{
         process_create_address_table_lookup, process_create_reward_center,
         process_edit_reward_center, process_fetch_reward_center_state,
         process_fetch_reward_center_treasury_balance, process_fund_reward_center,
+        process_withdraw_auction_house_treasury,
     },
     config::parse_solana_configuration,
     constants::PUBLIC_RPC_URLS,
@@ -115,6 +116,11 @@ fn run() -> Result<()> {
         Command::FetchTreasuryBalance { reward_center, .. } => {
             process_fetch_reward_center_treasury_balance(&client, &reward_center)?;
         },
+        Command::WithdrawAuctionHouse {
+            auction_house,
+            keypair,
+            amount,
+        } => process_withdraw_auction_house_treasury(&client, &keypair, &auction_house, amount)?,
     }
 
     info!("Done :)");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,7 @@ use reward_center_cli::{
         process_create_address_table_lookup, process_create_reward_center,
         process_edit_reward_center, process_fetch_reward_center_state,
         process_fetch_reward_center_treasury_balance, process_fund_reward_center,
-        process_withdraw_auction_house_treasury, process_withdraw_reward_center,
+        process_withdraw_auction_house_treasury, process_withdraw_reward_center_treasury,
     },
     config::parse_solana_configuration,
     constants::PUBLIC_RPC_URLS,
@@ -127,7 +127,7 @@ fn run() -> Result<()> {
             reward_center,
             keypair,
             amount,
-        } => process_withdraw_reward_center(&client, &keypair, &reward_center, amount)?,
+        } => process_withdraw_reward_center_treasury(&client, &keypair, &reward_center, amount)?,
     }
 
     info!("Done :)");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,7 @@ use reward_center_cli::{
         process_create_address_table_lookup, process_create_reward_center,
         process_edit_reward_center, process_fetch_reward_center_state,
         process_fetch_reward_center_treasury_balance, process_fund_reward_center,
-        process_withdraw_auction_house_treasury,
+        process_withdraw_auction_house_treasury, process_withdraw_reward_center,
     },
     config::parse_solana_configuration,
     constants::PUBLIC_RPC_URLS,
@@ -127,7 +127,7 @@ fn run() -> Result<()> {
             reward_center,
             keypair,
             amount,
-        } => process_withdraw_reward_center(&client, &keypair, &reward_center, amount),
+        } => process_withdraw_reward_center(&client, &keypair, &reward_center, amount)?,
     }
 
     info!("Done :)");

--- a/cli/src/opt.rs
+++ b/cli/src/opt.rs
@@ -43,6 +43,18 @@ pub enum Command {
         keypair: Option<PathBuf>,
     },
 
+    /// Create address lookup table
+    #[clap(name = "create-atl")]
+    CreateAddressTable {
+        /// Optional Auction House address
+        #[arg(short = 'a', long)]
+        auction_house: String,
+
+        /// Path to the address look up table's authority keypair file
+        #[arg(short, long)]
+        keypair: Option<PathBuf>,
+    },
+
     /// Edit reward center's reward rules
     #[clap(name = "edit")]
     Edit {

--- a/cli/src/opt.rs
+++ b/cli/src/opt.rs
@@ -47,7 +47,7 @@ pub enum Command {
     #[clap(name = "create-atl")]
     CreateAddressTable {
         /// Optional Auction House address
-        #[arg(short = 'a', long)]
+        #[arg(short, long)]
         auction_house: String,
 
         /// Path to the address look up table's authority keypair file
@@ -113,5 +113,21 @@ pub enum Command {
         /// Path to the reward center authority keypair file
         #[arg(short, long)]
         keypair: Option<PathBuf>,
+    },
+
+    /// Withdraw from Auction House treasury
+    #[clap(name = "withdraw-auction-house")]
+    WithdrawAuctionHouse {
+        /// Auction house address
+        #[arg(short = 'A', long)]
+        auction_house: String,
+
+        /// Path to the reward center authority keypair file
+        #[arg(short, long)]
+        keypair: Option<PathBuf>,
+
+        /// Amount to withdraw (excluding decimals)
+        #[arg(short = 'a', long)]
+        amount: u64,
     },
 }

--- a/sdk/auction-house/src/accounts.rs
+++ b/sdk/auction-house/src/accounts.rs
@@ -1,0 +1,22 @@
+use anchor_client::solana_sdk::pubkey::Pubkey;
+
+pub struct DelegateAuctioneerAccounts {
+    pub auction_house: Pubkey,
+    pub authority: Pubkey,
+    pub auctioneer_authority: Pubkey,
+}
+pub struct CreateAuctionHouseAccounts {
+    pub treasury_mint: Pubkey,
+    pub payer: Pubkey,
+    pub authority: Pubkey,
+    pub fee_withdrawal_destination: Pubkey,
+    pub treasury_withdrawal_destination: Pubkey,
+    pub treasury_withdrawal_destination_owner: Pubkey,
+}
+
+pub struct WithdrawFromTreasuryAccounts {
+    pub treasury_mint: Pubkey,
+    pub authority: Pubkey,
+    pub treasury_withdrawal_destination: Pubkey,
+    pub auction_house: Pubkey,
+}

--- a/sdk/auction-house/src/args.rs
+++ b/sdk/auction-house/src/args.rs
@@ -1,4 +1,5 @@
 use mpl_auction_house::AuthorityScope;
+
 pub struct CreateAuctionHouseData {
     pub seller_fee_basis_points: u16,
     pub requires_sign_off: bool,

--- a/sdk/auction-house/src/args.rs
+++ b/sdk/auction-house/src/args.rs
@@ -1,0 +1,10 @@
+use mpl_auction_house::AuthorityScope;
+pub struct CreateAuctionHouseData {
+    pub seller_fee_basis_points: u16,
+    pub requires_sign_off: bool,
+    pub can_change_sale_price: bool,
+}
+
+pub struct DelegateAuctioneerData {
+    pub scopes: Vec<AuthorityScope>,
+}

--- a/sdk/auction-house/src/lib.rs
+++ b/sdk/auction-house/src/lib.rs
@@ -1,27 +1,18 @@
+pub mod accounts;
+pub mod args;
+
+use accounts::{
+    CreateAuctionHouseAccounts, DelegateAuctioneerAccounts, WithdrawFromTreasuryAccounts,
+};
 use anchor_client::solana_sdk::sysvar;
-use anchor_client::solana_sdk::{instruction::Instruction, pubkey::Pubkey, system_program};
+use anchor_client::solana_sdk::{instruction::Instruction, system_program};
 use anchor_lang::{prelude::*, InstructionData};
 use anchor_spl::{associated_token::AssociatedToken, token::spl_token};
+use args::{CreateAuctionHouseData, DelegateAuctioneerData};
 use mpl_auction_house::pda::{
     find_auction_house_address, find_auction_house_fee_account_address,
     find_auction_house_treasury_address, find_auctioneer_pda,
 };
-use mpl_auction_house::AuthorityScope;
-
-pub struct CreateAuctionHouseAccounts {
-    pub treasury_mint: Pubkey,
-    pub payer: Pubkey,
-    pub authority: Pubkey,
-    pub fee_withdrawal_destination: Pubkey,
-    pub treasury_withdrawal_destination: Pubkey,
-    pub treasury_withdrawal_destination_owner: Pubkey,
-}
-
-pub struct CreateAuctionHouseData {
-    pub seller_fee_basis_points: u16,
-    pub requires_sign_off: bool,
-    pub can_change_sale_price: bool,
-}
 
 pub fn create_auction_house(
     CreateAuctionHouseAccounts {
@@ -78,16 +69,6 @@ pub fn create_auction_house(
     }
 }
 
-pub struct DelegateAuctioneerAccounts {
-    pub auction_house: Pubkey,
-    pub authority: Pubkey,
-    pub auctioneer_authority: Pubkey,
-}
-
-pub struct DelegateAuctioneerData {
-    pub scopes: Vec<AuthorityScope>,
-}
-
 pub fn delegate_auctioneer(
     DelegateAuctioneerAccounts {
         auction_house,
@@ -108,6 +89,40 @@ pub fn delegate_auctioneer(
     .to_account_metas(None);
 
     let data = mpl_auction_house::instruction::DelegateAuctioneer { scopes }.data();
+
+    Instruction {
+        program_id: mpl_auction_house::id(),
+        accounts,
+        data,
+    }
+}
+
+pub fn withdraw_from_treasury(
+    WithdrawFromTreasuryAccounts {
+        auction_house,
+        authority,
+        treasury_mint,
+        treasury_withdrawal_destination,
+    }: WithdrawFromTreasuryAccounts,
+    withdrawal_amount: u64,
+) -> Instruction {
+    let (auction_house_treasury, _) = find_auction_house_treasury_address(&auction_house);
+
+    let accounts = mpl_auction_house::accounts::WithdrawFromTreasury {
+        treasury_mint,
+        treasury_withdrawal_destination,
+        auction_house,
+        auction_house_treasury,
+        authority,
+        system_program: system_program::id(),
+        token_program: spl_token::id(),
+    }
+    .to_account_metas(None);
+
+    let data = mpl_auction_house::instruction::WithdrawFromTreasury {
+        amount: withdrawal_amount,
+    }
+    .data();
 
     Instruction {
         program_id: mpl_auction_house::id(),

--- a/sdk/auction-house/src/lib.rs
+++ b/sdk/auction-house/src/lib.rs
@@ -1,14 +1,13 @@
 pub mod accounts;
 pub mod args;
 
-use accounts::{
-    CreateAuctionHouseAccounts, DelegateAuctioneerAccounts, WithdrawFromTreasuryAccounts,
-};
+use accounts::*;
+use args::*;
+
 use anchor_client::solana_sdk::sysvar;
 use anchor_client::solana_sdk::{instruction::Instruction, system_program};
 use anchor_lang::{prelude::*, InstructionData};
 use anchor_spl::{associated_token::AssociatedToken, token::spl_token};
-use args::{CreateAuctionHouseData, DelegateAuctioneerData};
 use mpl_auction_house::pda::{
     find_auction_house_address, find_auction_house_fee_account_address,
     find_auction_house_treasury_address, find_auctioneer_pda,


### PR DESCRIPTION
The CLI now has two commands 
1. create-atl
2. withdraw-auction-house

create-atl makes sure to create an address table and add the mentioned address @ #31, although I wasn't confident regarding the `token_account` address @kespinola  

Example tx for ATL creation - https://explorer.solana.com/tx/5iAR4yaZ2U3Z71L75Z542r6gWg73F9xxBRARfzgNmCEq6UnCDkHXuLD3zGp7z4XJunKHgKXW16zRQqDrzmNPjkVS?cluster=devnet

Example tx for WithdrawTreasury - https://explorer.solana.com/tx/5UoFWP5YspYW97KJoFZz5r7AF3qQg2KxXVBMTvECzahF8NCjdjm9mqVYjq6VkgJBjmoDjDZX6L9x7rkHMdAjYJeb?cluster=devnet

withdraw-auction-house basically calls an instruction from Auction House named `WithdrawTreasury`

Closes #31 and #30 