### PR TITLE
Remove the decimal check on treasury mint vs reward token mint

### DIFF
--- a/program/src/reward_centers/create/mod.rs
+++ b/program/src/reward_centers/create/mod.rs
@@ -32,7 +32,6 @@ pub struct CreateRewardCenter<'info> {
     pub wallet: Signer<'info>,
 
     /// the mint of the token to use as rewards.
-    #[account(constraint = mint.decimals == auction_house_treasury_mint.decimals @ RewardCenterError::RewardMintDecimalMismatch)]
     pub mint: Account<'info, Mint>,
 
     // the mint of the accepted token currency for the associated auction house

--- a/program/tests/buy_listing.rs
+++ b/program/tests/buy_listing.rs
@@ -107,7 +107,7 @@ async fn buy_listing_success() {
         &reward_mint_pubkey,
         &reward_mint_authority_pubkey,
         Some(&reward_mint_authority_pubkey),
-        9,
+        7,
     )
     .unwrap();
 
@@ -121,16 +121,16 @@ async fn buy_listing_success() {
         &reward_center_reward_token_account,
         &reward_mint_authority_pubkey,
         &[],
-        100_000_000_000,
-        9,
+        100_000_000,
+        7,
     )
     .unwrap();
 
     let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
-            mathematical_operand: PayoutOperation::Multiple,
-            seller_reward_payout_basis_points: 1000,
-            payout_numeral: 5,
+            mathematical_operand: PayoutOperation::Divide,
+            seller_reward_payout_basis_points: 500,
+            payout_numeral: 7,
         },
     };
 
@@ -221,7 +221,7 @@ async fn buy_listing_success() {
     };
 
     let create_listing_params = CreateListingData {
-        price: reward_center_test::ONE_SOL,
+        price: reward_center_test::ONE_SOL * 7,
         token_size: 1,
         trade_state_bump,
         free_trade_state_bump,
@@ -304,7 +304,7 @@ async fn buy_listing_success() {
     };
 
     let buy_listing_params = BuyListingData {
-        price: reward_center_test::ONE_SOL,
+        price: reward_center_test::ONE_SOL * 7,
         token_size: 1,
         reward_mint: reward_mint_pubkey,
     };

--- a/sdk/auction-house/Cargo.lock
+++ b/sdk/auction-house/Cargo.lock
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-auction-house-sdk"
-version = "0.1.0"
+version = "1.2.4"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/sdk/auction-house/src/lib.rs
+++ b/sdk/auction-house/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod accounts;
 pub mod args;
 
-use accounts::*;
-use args::*;
+pub use args::*;
+pub use accounts::*;
 
 use anchor_client::solana_sdk::sysvar;
 use anchor_client::solana_sdk::{instruction::Instruction, system_program};

--- a/sdk/reward-center/Cargo.lock
+++ b/sdk/reward-center/Cargo.lock
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "hpl-reward-center-sdk"
-version = "0.1.0"
+version = "0.2.4"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/sdk/reward-center/src/lib.rs
+++ b/sdk/reward-center/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod accounts;
 pub mod args;
 
-use accounts::*;
+pub use accounts::*;
+
 use anchor_client::solana_sdk::{instruction::Instruction, pubkey::Pubkey, system_program, sysvar};
 use anchor_lang::{prelude::*, solana_program::instruction::AccountMeta, InstructionData};
 use args::*;


### PR DESCRIPTION
## Changes
- Able to support decimal not matching between the ah treasury mint and reward token mint