### PR TITLE
Add pNFT support to reward-center-program

### DIFF
--- a/program/Cargo.lock
+++ b/program/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "hpl-reward-center"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hpl-reward-center"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 description = "Reward buyers and sellers of NFTs with spl tokens"
 authors = ["Holaplex Developers <hola@holaplex.com>"]

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -45,8 +45,8 @@ pub mod reward_center {
         withdraw::reward_center::handler(ctx, withdraw_reward_center_funds_params)
     }
 
-    pub fn create_listing(
-        ctx: Context<CreateListing>,
+    pub fn create_listing<'info>(
+        ctx: Context<'_, '_, '_, 'info, CreateListing<'info>>,
         create_listing_params: CreateListingParams,
     ) -> Result<()> {
         listings::create::handler(ctx, create_listing_params)
@@ -59,7 +59,9 @@ pub mod reward_center {
         listings::update::handler(ctx, update_listing_params)
     }
 
-    pub fn close_listing(ctx: Context<CloseListing>) -> Result<()> {
+    pub fn close_listing<'info>(
+        ctx: Context<'_, '_, '_, 'info, CloseListing<'info>>,
+    ) -> Result<()> {
         listings::close::handler(ctx)
     }
 

--- a/program/src/listings/buy/mod.rs
+++ b/program/src/listings/buy/mod.rs
@@ -96,6 +96,7 @@ pub struct BuyListing<'info> {
 
     /// CHECK: assertion with mpl_auction_house assert_metadata_valid
     /// Metaplex metadata account decorating SPL mint account.
+    #[account(mut)]
     pub metadata: UncheckedAccount<'info>,
 
     /// Auction House treasury mint account.

--- a/program/src/listings/close/mod.rs
+++ b/program/src/listings/close/mod.rs
@@ -110,7 +110,7 @@ pub struct CloseListing<'info> {
     pub auction_house_program: Program<'info, AuctionHouseProgram>,
 }
 
-pub fn handler(ctx: Context<CloseListing>) -> Result<()> {
+pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, CloseListing<'info>>) -> Result<()> {
     let reward_center = &ctx.accounts.reward_center;
     let auction_house = &ctx.accounts.auction_house;
     let metadata = &ctx.accounts.metadata;
@@ -150,7 +150,7 @@ pub fn handler(ctx: Context<CloseListing>) -> Result<()> {
             accounts: cancel_listing_ctx_accounts,
             instruction_data: close_listing_params.data(),
             auctioneer_authority: ctx.accounts.reward_center.key(),
-            remaining_accounts: None,
+            remaining_accounts: Some(ctx.remaining_accounts),
         });
 
     invoke_signed(

--- a/program/src/listings/create/mod.rs
+++ b/program/src/listings/create/mod.rs
@@ -175,8 +175,8 @@ pub struct CreateListing<'info> {
     pub rent: Sysvar<'info, Rent>,
 }
 
-pub fn handler(
-    ctx: Context<CreateListing>,
+pub fn handler<'info>(
+    ctx: Context<'_, '_, '_, 'info, CreateListing<'info>>,
     CreateListingParams {
         token_size,
         trade_state_bump,
@@ -243,7 +243,7 @@ pub fn handler(
             accounts: create_listing_ctx_accounts,
             instruction_data: create_listing_params.data(),
             auctioneer_authority: ctx.accounts.reward_center.key(),
-            remaining_accounts: None,
+            remaining_accounts: Some(ctx.remaining_accounts),
         });
 
     invoke_signed(


### PR DESCRIPTION
Add ability for reward-center program to make pNFT calls via changes in auction-house laid out in https://github.com/metaplex-foundation/metaplex-program-library/pull/1030