### PR TITLE
Add space saving opts to `profile.release.`

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -39,3 +39,10 @@ env_logger="~0.9.0"
 spl-associated-token-account = { version = "~1.0.3", features = ["no-entrypoint"] }
 mpl-token-metadata = { version="~1.2.7", features = [ "no-entrypoint" ] }
 spl-token = { version = "~3.2",  features = ["no-entrypoint"] }
+
+[profile.release]
+overflow-checks = true     # Enable integer overflow checks.
+strip = true  # Automatically strip symbols from the binary.
+opt-level = "z" 
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Reduces binary size by 232224 bytes (~20%).